### PR TITLE
Update carbon/grid to v11.11.0 and carbon/styles to v1.21.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
     "lint": "vue-cli-service lint"
   },
   "dependencies": {
-    "@carbon/grid": "^11.10.0",
+    "@carbon/grid": "^11.11.0",
     "@carbon/ibmdotcom-web-components": "1.25.0",
-    "@carbon/styles": "^1.20.0",
+    "@carbon/styles": "^1.21.0",
     "@carbon/vue": "^2.45.0",
     "axios": "^1.2.3",
     "vue": "^2.7.14",

--- a/yarn.lock
+++ b/yarn.lock
@@ -997,15 +997,15 @@
   resolved "https://registry.yarnpkg.com/@carbon/colors/-/colors-10.37.1.tgz#6e5a62fedb256bab56873f7b42985b515521b856"
   integrity sha512-Bst1o2RGB0Fpdd2p9y+2fl2oxtXuI0RiVhxKBChKOPZkeBJZTWj1jNgQuNK1ZALHWGX9rL75i7tJmhlXbukfmA==
 
-"@carbon/colors@^11.11.0":
-  version "11.11.0"
-  resolved "https://registry.yarnpkg.com/@carbon/colors/-/colors-11.11.0.tgz#564435be2bd64487c6b72187323f27c55bb043b4"
-  integrity sha512-dQyPt9zLN4DwkIWynEKl8t0EI7yEFD9ZbN3UQYRANL0htH7QsgFyStm3TQ91IsCMRAfP1BHF2vsIPXEggPcUqA==
+"@carbon/colors@^11.12.0":
+  version "11.12.0"
+  resolved "https://registry.yarnpkg.com/@carbon/colors/-/colors-11.12.0.tgz#429189e873d7011161370ede814b79f76859cd5a"
+  integrity sha512-rN/e6EXgS1RM8C/K0qQ/4/zE+En8iMGDE9u6BNLQ9ig2V2KTYncCdhItJW0rAbL7tt8xeP0UrACijS/XCqsm6w==
 
-"@carbon/feature-flags@^0.11.0":
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/@carbon/feature-flags/-/feature-flags-0.11.0.tgz#66a115dd76c1c75272d61665b8c85ec3ca4aea78"
-  integrity sha512-5sQ/qrR5N7/uNI2Pj0PjN/tc93Dcy8cKV4p/jxXAmhGGaWgOYetjwKYUrHBX4RoFRqzM3gn0iAyrwC77hBX7rA==
+"@carbon/feature-flags@^0.12.0":
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/@carbon/feature-flags/-/feature-flags-0.12.0.tgz#5833161a4449541113d416708967eae4e12ce6cf"
+  integrity sha512-7jspPbQNk//S787QDtDI/jAGEt2MKc0aHJEQ32UFXXNb8hIr/VpVQTTu7OZoUiSF23F3Dsnr4HcEXsj6Nq9Ikw==
 
 "@carbon/grid@10.43.1", "@carbon/grid@^10.43.0":
   version "10.43.1"
@@ -1015,12 +1015,12 @@
     "@carbon/import-once" "^10.7.0"
     "@carbon/layout" "^10.37.1"
 
-"@carbon/grid@^11.10.0":
-  version "11.10.0"
-  resolved "https://registry.yarnpkg.com/@carbon/grid/-/grid-11.10.0.tgz#c22b4447c559b6e99cc3784ce615294efb337314"
-  integrity sha512-DL0us6Ms0YNDjW7a+8ZMByLkg1rQ2A0M/9e+LdnseyD/aWfUWGsPH/S2h7FNkNClywPOYwbU+NgYY8N72F7C5g==
+"@carbon/grid@^11.11.0":
+  version "11.11.0"
+  resolved "https://registry.yarnpkg.com/@carbon/grid/-/grid-11.11.0.tgz#9cd04bb7627013c6e9a8d2db430dca75e8348c5b"
+  integrity sha512-07U2cC5lgvy7gWveUtE0wuYUxu6Dndglnajy1FJAeV7BEd2t6cgU/t7AOaL8RhoXPjE7tarN5tnZImw5nmzQYQ==
   dependencies:
-    "@carbon/layout" "^11.10.0"
+    "@carbon/layout" "^11.11.0"
 
 "@carbon/ibmdotcom-services@1.40.0":
   version "1.40.0"
@@ -1128,33 +1128,38 @@
   resolved "https://registry.yarnpkg.com/@carbon/layout/-/layout-10.37.1.tgz#697ac4ba0500f55163cd84e0dc200d637fd41beb"
   integrity sha512-iX8rWc2CkFB7W7wi5NLa3pVRVb/jRI2KrVDna3FO3X3DgNz3zoRCgN+r2c+8FEhpJWeUwds5aDzTWUuTtlOT3w==
 
-"@carbon/layout@^11.10.0":
-  version "11.10.0"
-  resolved "https://registry.yarnpkg.com/@carbon/layout/-/layout-11.10.0.tgz#995ecc9d3ea8d5eca6982825b819062b097c738d"
-  integrity sha512-rQm5V0w+J8LsNnwq/Z1rXVHxlFbcccu06eJGqi9uGkrZZLT7UXJz9E27gIstxyiYeE+Sd7wq6iQayxWvahYjCQ==
+"@carbon/layout@^11.11.0":
+  version "11.11.0"
+  resolved "https://registry.yarnpkg.com/@carbon/layout/-/layout-11.11.0.tgz#cb419d8c903129bb0f8484a0437e373c52a27c48"
+  integrity sha512-0AuBxoJ+4HiYDIou0xR/jRtGDjTZ2ew1qeViQd04aM0GdZDGhjPTwU9u9CLCKAZEK4dYcewqWat1FQI4diYaOA==
 
 "@carbon/motion@10.29.0":
   version "10.29.0"
   resolved "https://registry.yarnpkg.com/@carbon/motion/-/motion-10.29.0.tgz#1e78c70d396ad3b9363f7a0c7e36ce9bac3d5702"
   integrity sha512-b8Cc9vgMlkQfLQAwq9Zt1/UfsrtGcWQpf0kK5gCamAuSmNSFWYJSwqbY9MeodxM2xNfXrxFcEFwqwy/E7egxUw==
 
-"@carbon/motion@^11.0.0", "@carbon/motion@^11.8.0":
+"@carbon/motion@^11.0.0":
   version "11.8.0"
   resolved "https://registry.yarnpkg.com/@carbon/motion/-/motion-11.8.0.tgz#9f00378a3cfedb44f66a98720ed9f581ae8ca642"
   integrity sha512-g58Y63h/Rhu7lzkdwOLIMAj4UPLYKAJrIC5evJHG8R1SVkCLv1OYbQ0wXv7QTWxOj6nUqCF3nqJBnRGfzUFTWg==
 
-"@carbon/styles@^1.20.0":
-  version "1.20.0"
-  resolved "https://registry.yarnpkg.com/@carbon/styles/-/styles-1.20.0.tgz#ba8107a6cc9e3694b9edcb7b3ea863ed41ae6dc7"
-  integrity sha512-fvnTrhkdRgIjvCrRIKWYfoYSO7rDkJf+GRPUpJAcMjm7O27bsEITXsIO2YlZF4LT4kjtNyOpP0fhoyGX6M6QUA==
+"@carbon/motion@^11.9.0":
+  version "11.9.0"
+  resolved "https://registry.yarnpkg.com/@carbon/motion/-/motion-11.9.0.tgz#8b0103d0ce437eb58e82b07538a1544d9b15868e"
+  integrity sha512-kLWvm0Y6QH+2sZm+TKk5PPHONlZZFFY5QelyZrCkKlzB5oU2Nne597ETHnu1SomOscDqJjc/zhkxIsx9dJLBIw==
+
+"@carbon/styles@^1.21.0":
+  version "1.21.0"
+  resolved "https://registry.yarnpkg.com/@carbon/styles/-/styles-1.21.0.tgz#47d2e3506af87bb0cbbc2a3c808626646ed602fd"
+  integrity sha512-7kIDGfLlMIcCwJG0y3jfyadHpAmOCth/kHdHxqxKzBmT/BDGiEmEsrdvknUXYJeGcwVA0s54xewVkpnnSFEVsA==
   dependencies:
-    "@carbon/colors" "^11.11.0"
-    "@carbon/feature-flags" "^0.11.0"
-    "@carbon/grid" "^11.10.0"
-    "@carbon/layout" "^11.10.0"
-    "@carbon/motion" "^11.8.0"
-    "@carbon/themes" "^11.15.0"
-    "@carbon/type" "^11.14.0"
+    "@carbon/colors" "^11.12.0"
+    "@carbon/feature-flags" "^0.12.0"
+    "@carbon/grid" "^11.11.0"
+    "@carbon/layout" "^11.11.0"
+    "@carbon/motion" "^11.9.0"
+    "@carbon/themes" "^11.16.0"
+    "@carbon/type" "^11.15.0"
     "@ibm/plex" "6.0.0-next.6"
 
 "@carbon/telemetry@0.0.0-alpha.6":
@@ -1188,14 +1193,14 @@
     "@carbon/type" "^10.45.0"
     color "^3.1.2"
 
-"@carbon/themes@^11.15.0":
-  version "11.15.0"
-  resolved "https://registry.yarnpkg.com/@carbon/themes/-/themes-11.15.0.tgz#66c9a473fb1877cf94a1fb8f80854646787b797c"
-  integrity sha512-Cxd+JTCJ9ULIpjMzpdQdKJ6u0G7yYuYRsVn/FKJ1ChkKmsSC/WI/IYkdbJHdfIpB7gWHaz8PGg9LQWSxQth8Zw==
+"@carbon/themes@^11.16.0":
+  version "11.16.0"
+  resolved "https://registry.yarnpkg.com/@carbon/themes/-/themes-11.16.0.tgz#21bab5d33f4bd249a100bc42787b51142580ba49"
+  integrity sha512-t5323D66p5M6ev9HwMo5tQUE5M1zQP+fa2KExOkHzyJXQfbR3rDSL3y8O/ALrnLgYfBKTftQCGOcUnxhR3LOTQ==
   dependencies:
-    "@carbon/colors" "^11.11.0"
-    "@carbon/layout" "^11.10.0"
-    "@carbon/type" "^11.14.0"
+    "@carbon/colors" "^11.12.0"
+    "@carbon/layout" "^11.11.0"
+    "@carbon/type" "^11.15.0"
     color "^4.0.0"
 
 "@carbon/type@10.45.0":
@@ -1214,13 +1219,13 @@
     "@carbon/grid" "^10.43.0"
     "@carbon/import-once" "^10.7.0"
 
-"@carbon/type@^11.14.0":
-  version "11.14.0"
-  resolved "https://registry.yarnpkg.com/@carbon/type/-/type-11.14.0.tgz#154b83c5791bb7beebf9117eb571a00c8463be7e"
-  integrity sha512-t8agJ2FfX9V7sYbmoIXYbM+yu62whozBlbSaJVnrMFpvRPOsEdWt0US4CAdyCvxytRsJqr+SfyScXx2phUrFgg==
+"@carbon/type@^11.15.0":
+  version "11.15.0"
+  resolved "https://registry.yarnpkg.com/@carbon/type/-/type-11.15.0.tgz#a22ad271803f866b4955e1c4e483221de15b2cda"
+  integrity sha512-oJm8imiLUF5x7AYaiuExhGfhF/aep8STvV4ckQ9VrPCVFwytJ1haJFmyDU2ssYNiTfgjVN0foy6sNbHMZYM0pg==
   dependencies:
-    "@carbon/grid" "^11.10.0"
-    "@carbon/layout" "^11.10.0"
+    "@carbon/grid" "^11.11.0"
+    "@carbon/layout" "^11.11.0"
 
 "@carbon/vue@^2.45.0":
   version "2.45.0"


### PR DESCRIPTION
Closes #34 

This PR does not update: `@carbon/ibmdotcom-web-components` to `v1.27.0` because of:
- https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/9923
- https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/9936

Signed-off-by: Alessandro Pomponio <alessandro.pomponio1@ibm.com>