### PR TITLE
fix(style): ensure progress indicator modal is not shifted upwards on mobile

### DIFF
--- a/src/components/St4sdBestPracticesProgressIndicator/St4sdModal.vue
+++ b/src/components/St4sdBestPracticesProgressIndicator/St4sdModal.vue
@@ -1,5 +1,5 @@
 <template>
-  <bx-modal id="strong-versioning-modal">
+  <bx-modal id="strong-versioning-modal" class="no-transform">
     <bx-modal-header>
       <bx-modal-close-button></bx-modal-close-button>
       <bx-modal-label>ST4SD Best Practices</bx-modal-label>
@@ -82,6 +82,16 @@ export default {
 </script>
 
 <style lang="scss">
+// The modal was slightly shifted up in small screen (smaller than 840)
+// this code will change transofrm from translate3d(0px, -24px, 0px)
+// to none when the screen width falls under 840
+/// @link https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/10480
+@media screen and (max-width: 839px) {
+  .no-transform::part(dialog) {
+    transform: none;
+  }
+}
+
 bx-modal-body {
   padding-right: 0;
 }


### PR DESCRIPTION
## Context

Resolves https://github.com/st4sd/st4sd-registry-ui/issues/47 by removing a `translate3d(0px, -24px, 0px)` transformation that was applied to modals on small screens.

## Change list

- Sets `transform: none;` for the modal on small screens

## Checklist

Ensure your PR meets the following requirements:

- [x] This PR is associated to one (or more) issues that are open
- [ ] I have signed off my commits (using `git commit -s`)
- [x] I agree with the ST4SD Code of Conduct
