### PR TITLE
style: ensure words are not split in ExperimentView when using small screens

### DIFF
--- a/src/components/ExperimentView/ExperimentInputs.vue
+++ b/src/components/ExperimentView/ExperimentInputs.vue
@@ -51,3 +51,8 @@ export default {
   },
 };
 </script>
+<style
+  lang="css"
+  scoped
+  src="../../styles/structured-list-grid-column-styles.css"
+></style>

--- a/src/components/ExperimentView/ExperimentParameterisation.vue
+++ b/src/components/ExperimentView/ExperimentParameterisation.vue
@@ -378,8 +378,12 @@ export default {
   },
 };
 </script>
-
-<style>
+<style
+  lang="css"
+  scoped
+  src="../../styles/structured-list-grid-column-styles.css"
+></style>
+<style scoped>
 bx-unordered-list {
   padding-left: 0;
 }

--- a/src/components/ExperimentView/PackageInfoBase.vue
+++ b/src/components/ExperimentView/PackageInfoBase.vue
@@ -150,9 +150,8 @@ export default {
   },
 };
 </script>
-
-<style>
-dds-structured-list {
-  overflow-x: hidden;
-}
-</style>
+<style
+  lang="css"
+  scoped
+  src="../../styles/structured-list-grid-column-styles.css"
+></style>

--- a/src/components/ExperimentView/PackageInfoContainer.vue
+++ b/src/components/ExperimentView/PackageInfoContainer.vue
@@ -40,3 +40,8 @@ export default {
   },
 };
 </script>
+<style
+  lang="css"
+  scoped
+  src="../../styles/structured-list-grid-column-styles.css"
+></style>

--- a/src/components/ExperimentView/PackageInfoMetadata.vue
+++ b/src/components/ExperimentView/PackageInfoMetadata.vue
@@ -100,3 +100,8 @@ export default {
   },
 };
 </script>
+<style
+  lang="css"
+  scoped
+  src="../../styles/structured-list-grid-column-styles.css"
+></style>

--- a/src/components/ExperimentView/VirtualExperimentInterface.vue
+++ b/src/components/ExperimentView/VirtualExperimentInterface.vue
@@ -15,10 +15,10 @@
         <dds-structured-list>
           <dds-structured-list-head>
             <dds-structured-list-header-row>
-              <dds-structured-list-header-cell
+              <dds-structured-list-header-cell class="cds--col-sm-1"
                 >Property name</dds-structured-list-header-cell
               >
-              <dds-structured-list-header-cell
+              <dds-structured-list-header-cell class="cds--col-sm-3"
                 >Property description</dds-structured-list-header-cell
               >
             </dds-structured-list-header-row>
@@ -29,10 +29,10 @@
                 .propertiesSpec"
               :key="property.name"
             >
-              <dds-structured-list-cell>{{
+              <dds-structured-list-cell class="cds--col-sm-1">{{
                 property.name
               }}</dds-structured-list-cell>
-              <dds-structured-list-cell>
+              <dds-structured-list-cell class="cds--col-sm-3">
                 {{ property.description }}
               </dds-structured-list-cell>
             </dds-structured-list-row>
@@ -55,5 +55,8 @@ export default {
   },
 };
 </script>
-
-<style></style>
+<style
+  lang="css"
+  scoped
+  src="../../styles/structured-list-grid-column-styles.css"
+></style>

--- a/src/styles/structured-list-grid-column-styles.css
+++ b/src/styles/structured-list-grid-column-styles.css
@@ -1,0 +1,13 @@
+/* Styling for the structured list cells of metadata, 
+preset parameters and base package info tables 
+in Experiment View*/
+
+.cds--col-sm-1 {
+  overflow-wrap: normal;
+}
+.cds--col-sm-3 {
+  padding-left: 2.5rem;
+}
+dds-structured-list {
+  overflow-x: hidden;
+}


### PR DESCRIPTION

## Context

Resolves: https://github.com/st4sd/st4sd-registry-ui/issues/49

## Change list

Write a few bullet points of the changes contained in this PR:

- Changed overflow-wrap to normal, and added left padding to the second cell of the row
- Moved the styles in a separate file and linked it in all related files
- Added the same style to the first structured list of experiment view

## Checklist

Ensure your PR meets the following requirements:

- [x] This PR is associated to one (or more) issues that are open
- [x] I have signed off my commits (using `git commit -s`)
- [x] I agree with the ST4SD Code of Conduct
