### PR TITLE
style(mobile): remove left margin from Hero elements on ExperimentVie…

### DIFF
--- a/src/components/ExperimentView/PageHero.vue
+++ b/src/components/ExperimentView/PageHero.vue
@@ -97,3 +97,12 @@ dds-structured-list-cell {
   padding-top: 2rem;
 }
 </style>
+<style scoped lang="scss">
+@media screen and (max-width: 671px) {
+  dds-content-block-copy,
+  dds-content-block-heading,
+  dds-text-cta {
+    margin-left: 0;
+  }
+}
+</style>


### PR DESCRIPTION
…w (#158)

Resolves: https://github.com/st4sd/st4sd-registry-ui/issues/51
Resolves: https://github.ibm.com/st4sd/overview/issues/495

## Change list
- Removed the margin for dds-content-block-copy, dds-content-block-heading and dds-text-cta for small screens under 671px wide.

## Checklist

Ensure your PR meets the following requirements:

- [x] This PR is associated to one (or more) issues that are open
- [x] I have signed off my commits (using `git commit -s`)
- [x] I agree with the ST4SD Code of Conduct
